### PR TITLE
Enhance error check for `ADD_RT_NO_VNI`

### DIFF
--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/onmetal/controller-utils/clientutils"
@@ -125,7 +123,7 @@ func (r *NetworkReconciler) reconcile(ctx context.Context, log logr.Logger, netw
 
 	log.V(1).Info("Creating dpdk default route if not exists")
 	if err := r.createDefaultRouteIfNotExists(ctx, vni); err != nil {
-		if strings.Contains(err.Error(), strconv.Itoa(dpdk.ADD_RT_NO_VNI)) {
+		if dpdk.IsStatusErrorCode(err, dpdk.ADD_RT_NO_VNI) {
 			log.V(1).Info("VNI doesn't exist in dp-service, requeueing")
 			return ctrl.Result{Requeue: true}, nil
 		}


### PR DESCRIPTION
The current check of

```go
if strings.Contains(err.Error(), strconv.Itoa(dpdk.ADD_RT_NO_VNI)) {
```

matches any error string that contains `255` (the value of `dpdk.ADD_RT_NO_VNI`), causing potentially unwanted errors to be ignored / requeued upon.

This change makes use of

```go
if dpdk.IsStatusErrorCode(err, dpdk.ADD_RT_NO_VNI) {
```

to only catch / handle dpdk errors with the actual expected error code.