### PR TITLE
Bump golangci-lint version to fix linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43.0
+          version: v1.50.0


### PR DESCRIPTION
# Proposed Changes
This should resolve some of the `golangci-lint` issues that arose due to go1.19, see
* https://github.com/golangci/golangci-lint/issues/2374
* https://github.com/golangci/golangci-lint/pull/3037
