### PR TITLE
Make NAT a pointer

### DIFF
--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -38,7 +38,7 @@ type NetworkInterfaceSpec struct {
 	// Loadbalancer Targets are the provided Prefix
 	LoadBalancerTargets []IPPrefix `json:"loadBalancerTargets,omitempty"`
 	// NATInfo is detailed information about the NAT on this interface
-	NAT NATDetails `json:"nat,omitempty"`
+	NAT *NATDetails `json:"nat,omitempty"`
 	// NodeName is the name of the node on which the interface should be created.
 	NodeName *string `json:"nodeName,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -295,7 +295,11 @@ func (in *NetworkInterfaceSpec) DeepCopyInto(out *NetworkInterfaceSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.NAT.DeepCopyInto(&out.NAT)
+	if in.NAT != nil {
+		in, out := &in.NAT, &out.NAT
+		*out = new(NATDetails)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NodeName != nil {
 		in, out := &in.NodeName, &out.NodeName
 		*out = new(string)


### PR DESCRIPTION
# Proposed Changes

NATDetails being a pointer could be useful for clients to set it to nil while not using the feature. 

Fixes #