### PR TITLE
Use the correct base for the pci device number during conversion

### DIFF
--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -948,7 +948,7 @@ func (r *NetworkInterfaceReconciler) convertToDPDKDevice(addr ghw.PCIAddress) (s
 		return "", fmt.Errorf("error parsing address function %s: %w", addr.Function, err)
 	}
 
-	pciDevice, err := strconv.ParseUint(addr.Device, 8, 64)
+	pciDevice, err := strconv.ParseUint(addr.Device, 16, 64)
 	if err != nil {
 		return "", fmt.Errorf("error parsing address device %s: %w", addr.Device, err)
 	}


### PR DESCRIPTION
Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>