### PR TITLE
Updated gRPC return values for LB functions

### DIFF
--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -288,14 +288,14 @@ func (r *NetworkInterfaceReconciler) removeLBTargetRouteIfExists(ctx context.Con
 }
 
 func (r *NetworkInterfaceReconciler) deleteDPDKLBTargetIfExists(ctx context.Context, nicUID types.UID, prefix netip.Prefix) error {
-	if err := r.DPDK.DeleteLBPrefix(ctx, nicUID, prefix); dpdk.IgnoreStatusErrorCode(err, dpdk.NO_VM) != nil {
-		return fmt.Errorf("error deleting lb target: %w", err)
+	if err := r.DPDK.DeleteLBPrefix(ctx, nicUID, prefix); dpdk.IgnoreStatusErrorCode(err, dpdk.NO_VM) != nil && dpdk.IgnoreStatusErrorCode(err, dpdk.NOT_FOUND) != nil {
+		return fmt.Errorf("error deleting lb prefix: %w", err)
 	}
 	return nil
 }
 
 func (r *NetworkInterfaceReconciler) deleteDPDKPrefixIfExists(ctx context.Context, nicUID types.UID, prefix netip.Prefix) error {
-	if err := r.DPDK.DeletePrefix(ctx, nicUID, prefix); dpdk.IgnoreStatusErrorCode(err, dpdk.NO_VM) != nil {
+	if err := r.DPDK.DeletePrefix(ctx, nicUID, prefix); dpdk.IgnoreStatusErrorCode(err, dpdk.NO_VM) != nil && dpdk.IgnoreStatusErrorCode(err, dpdk.NOT_FOUND) != nil {
 		return fmt.Errorf("error deleting prefix: %w", err)
 	}
 	return nil

--- a/dpdk/errors.go
+++ b/dpdk/errors.go
@@ -50,6 +50,7 @@ const (
 	VNF_INSERT      = 401
 	VM_HANDLE       = 402
 	NO_BACKIP       = 421
+	NO_LB           = 422
 	NO_DROP_SUPPORT = 441
 )
 

--- a/dpdkmetalbond/dpdkmetalbond.go
+++ b/dpdkmetalbond/dpdkmetalbond.go
@@ -133,7 +133,7 @@ func (c *Client) AddRoute(vni mb.VNI, dest mb.Destination, hop mb.NextHop) error
 			Spec: dpdk.LBTargetIPSpec{
 				Address: hop.TargetAddress,
 			},
-		}); err != nil {
+		}); dpdk.IgnoreStatusErrorCode(err, dpdk.ALREADY_EXISTS) != nil {
 			return fmt.Errorf("error creating lb target: %w", err)
 		}
 		return nil
@@ -204,7 +204,8 @@ func (c *Client) RemoveRoute(vni mb.VNI, dest mb.Destination, hop mb.NextHop) er
 				Address: hop.TargetAddress,
 			},
 		}); dpdk.IgnoreStatusErrorCode(err, dpdk.NOT_FOUND) != nil &&
-			dpdk.IgnoreStatusErrorCode(err, dpdk.NO_BACKIP) != nil {
+			dpdk.IgnoreStatusErrorCode(err, dpdk.NO_BACKIP) != nil &&
+			dpdk.IgnoreStatusErrorCode(err, dpdk.NO_LB) != nil {
 			return fmt.Errorf("error deleting lb target: %w", err)
 		}
 		return nil


### PR DESCRIPTION
This is the companion PR of net-dpservice:#306

It seems to have too little changes, but from what I can tell it checks out, as many instances are also guarded a previous call to a list or get.