### PR TITLE
Refactor helper code on caching, metalbond callbacks and wrappers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY client/ client/
 COPY controllers/ controllers/
-COPY dpdkmetalbond/ dpdkmetalbond/
+COPY internal/ internal/
 COPY encoding/ encoding/
 COPY metalbond/ metalbond/
 COPY netfns/ netfns/

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -1468,12 +1468,13 @@ func networkReconcile(ctx context.Context, network metalnetv1alpha1.Network) err
 	GinkgoHelper()
 
 	reconciler := &NetworkReconciler{
-		Client:        k8sClient,
-		DPDK:          dpdkClient,
-		Metalbond:     metalbondClient,
-		MBInternal:    mbClient,
-		RouterAddress: netip.MustParseAddr("::1"),
-		NodeName:      testNode,
+		Client:           k8sClient,
+		DPDK:             dpdkClient,
+		RouteUtil:        metalbondRouteUtil,
+		MetalnetCache:    metalnetCache,
+		MetalnetMBClient: metalnetMBClient,
+		RouterAddress:    netip.MustParseAddr("::1"),
+		NodeName:         testNode,
 	}
 
 	// Loop the reconciler until Requeue is false or error occurs
@@ -1505,7 +1506,7 @@ func ifaceReconcile(ctx context.Context, networkInterface metalnetv1alpha1.Netwo
 		Client:        k8sClient,
 		EventRecorder: &record.FakeRecorder{},
 		DPDK:          dpdkClient,
-		Metalbond:     metalbondClient,
+		RouteUtil:     metalbondRouteUtil,
 		NodeName:      testNode,
 		NetFnsManager: netFnsManager,
 		PublicVNI:     100,
@@ -1539,8 +1540,8 @@ func lbReconcile(ctx context.Context, loadBalancer metalnetv1alpha1.LoadBalancer
 		Client:        k8sClient,
 		EventRecorder: &record.FakeRecorder{},
 		DPDK:          dpdkClient,
-		MBInternal:    mbClient,
-		Metalbond:     metalbondClient,
+		RouteUtil:     metalbondRouteUtil,
+		MetalnetCache: metalnetCache,
 		NodeName:      testNode,
 		PublicVNI:     100,
 	}

--- a/internal/metalnet_cache.go
+++ b/internal/metalnet_cache.go
@@ -1,0 +1,136 @@
+// Copyright 2022 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/netip"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type MetalnetCache struct {
+	lbServerMap    map[uint32]map[string]types.UID
+	peeredPrefixes map[uint32]map[uint32][]netip.Prefix
+	peeredVnis     map[uint32]sets.Set[uint32]
+	mtxPeeredVnis  sync.RWMutex
+	log            *logr.Logger
+}
+
+func NewMetalnetCache(log *logr.Logger) *MetalnetCache {
+	return &MetalnetCache{
+		lbServerMap:    make(map[uint32]map[string]types.UID),
+		peeredPrefixes: make(map[uint32]map[uint32][]netip.Prefix),
+		peeredVnis:     make(map[uint32]sets.Set[uint32]),
+		log:            log,
+	}
+}
+
+func (c *MetalnetCache) SetPeeredPrefixes(vni uint32, peeredPrefixes map[uint32][]netip.Prefix) {
+	c.peeredPrefixes[vni] = peeredPrefixes
+}
+
+func (c *MetalnetCache) GetPeeredPrefixes(vni uint32) (map[uint32][]netip.Prefix, bool) {
+	prefixes, ok := c.peeredPrefixes[vni]
+	if !ok {
+		return nil, false
+	}
+
+	// Create a new map and avoid modification from outside
+	copiedPrefixes := make(map[uint32][]netip.Prefix)
+	for k, v := range prefixes {
+		copiedPrefixes[k] = append([]netip.Prefix(nil), v...)
+	}
+
+	return copiedPrefixes, true
+}
+
+func (c *MetalnetCache) IsVniPeered(vni uint32) bool {
+	c.mtxPeeredVnis.RLock()
+	defer c.mtxPeeredVnis.RUnlock()
+	for _, peeredVnis := range c.peeredVnis {
+		if peeredVnis.Has(vni) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *MetalnetCache) GetPeerVnis(vni uint32) (sets.Set[uint32], bool) {
+	c.mtxPeeredVnis.RLock()
+	defer c.mtxPeeredVnis.RUnlock()
+	vnis, ok := c.peeredVnis[vni]
+	if !ok {
+		return sets.New[uint32](), false
+	}
+	return vnis, true
+}
+
+func (c *MetalnetCache) AddVniToPeerVnis(vni, peeredVNI uint32) error {
+	c.mtxPeeredVnis.Lock()
+	defer c.mtxPeeredVnis.Unlock()
+	c.log.V(1).Info("Adding to peered VNI list", "VNI", vni, "peeredVNI", peeredVNI)
+	set, ok := c.peeredVnis[vni]
+	if !ok {
+		set = sets.New[uint32]()
+		c.peeredVnis[vni] = set
+	}
+	set.Insert(peeredVNI)
+	c.log.V(1).Info("Added to peered VNI list", "VNI", vni, "peeredVNI", peeredVNI)
+	return nil
+}
+
+func (c *MetalnetCache) RemoveVniFromPeerVnis(vni, peeredVNI uint32) error {
+	c.mtxPeeredVnis.Lock()
+	defer c.mtxPeeredVnis.Unlock()
+	c.log.V(1).Info("Removing from peered VNI list", "VNI", vni, "peeredVNI", peeredVNI)
+	set, ok := c.peeredVnis[vni]
+	if !ok {
+		return nil
+	}
+	set.Delete(peeredVNI)
+	c.log.V(1).Info("Removed from peered VNI list", "VNI", vni, "peeredVNI", peeredVNI)
+	return nil
+}
+
+func (c *MetalnetCache) AddLoadBalancerServer(vni uint32, ip string, uid types.UID) error {
+	if _, exists := c.lbServerMap[vni]; !exists {
+		c.lbServerMap[vni] = make(map[string]types.UID)
+	}
+	c.lbServerMap[vni][ip] = uid
+	return nil
+}
+
+func (c *MetalnetCache) RemoveLoadBalancerServer(ip string, uid types.UID) error {
+	for _, innerMap := range c.lbServerMap {
+		for keyIp, value := range innerMap {
+			if ip == keyIp && value == uid {
+				delete(innerMap, ip)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *MetalnetCache) GetLoadBalancerServer(vni uint32, ip string) (types.UID, bool) {
+	innerMap, exists := c.lbServerMap[vni]
+	if !exists {
+		return "", false
+	}
+	uid, exists := innerMap[ip]
+	return uid, exists
+}

--- a/metalbond/route_util.go
+++ b/metalbond/route_util.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,21 +22,21 @@ import (
 	"github.com/onmetal/metalbond/pb"
 )
 
-type Client interface {
-	AddRoute(ctx context.Context, vni VNI, destination Destination, nextHop NextHop) error
-	RemoveRoute(ctx context.Context, vni VNI, destination Destination, nextHop NextHop) error
+type RouteUtil interface {
+	AnnounceRoute(ctx context.Context, vni VNI, destination Destination, nextHop NextHop) error
+	WithdrawRoute(ctx context.Context, vni VNI, destination Destination, nextHop NextHop) error
 	Subscribe(ctx context.Context, vni VNI) error
 	Unsubscribe(ctx context.Context, vni VNI) error
 	IsSubscribed(ctx context.Context, vni VNI) bool
 	GetRoutesForVni(ctx context.Context, vni VNI) error
 }
 
-type client struct {
+type MBRouteUtil struct {
 	metalbond *metalbond.MetalBond
 }
 
-func NewClient(mb *metalbond.MetalBond) Client {
-	return &client{mb}
+func NewMBRouteUtil(mb *metalbond.MetalBond) *MBRouteUtil {
+	return &MBRouteUtil{mb}
 }
 
 type VNI = metalbond.VNI
@@ -64,7 +64,7 @@ type NextHop struct {
 	TargetNATMaxPort uint16
 }
 
-func (c *client) AddRoute(_ context.Context, vni VNI, destination Destination, nextHop NextHop) error {
+func (c *MBRouteUtil) AnnounceRoute(_ context.Context, vni VNI, destination Destination, nextHop NextHop) error {
 	return c.metalbond.AnnounceRoute(vni, metalbond.Destination{
 		IPVersion: netIPAddrIPVersion(destination.Prefix.Addr()),
 		Prefix:    destination.Prefix,
@@ -77,7 +77,7 @@ func (c *client) AddRoute(_ context.Context, vni VNI, destination Destination, n
 	})
 }
 
-func (c *client) RemoveRoute(_ context.Context, vni VNI, destination Destination, nextHop NextHop) error {
+func (c *MBRouteUtil) WithdrawRoute(_ context.Context, vni VNI, destination Destination, nextHop NextHop) error {
 	return c.metalbond.WithdrawRoute(vni, metalbond.Destination{
 		IPVersion: netIPAddrIPVersion(destination.Prefix.Addr()),
 		Prefix:    destination.Prefix,
@@ -90,18 +90,18 @@ func (c *client) RemoveRoute(_ context.Context, vni VNI, destination Destination
 	})
 }
 
-func (c *client) Subscribe(_ context.Context, vni VNI) error {
+func (c *MBRouteUtil) Subscribe(_ context.Context, vni VNI) error {
 	return c.metalbond.Subscribe(vni)
 }
 
-func (c *client) Unsubscribe(_ context.Context, vni VNI) error {
+func (c *MBRouteUtil) Unsubscribe(_ context.Context, vni VNI) error {
 	return c.metalbond.Unsubscribe(vni)
 }
 
-func (c *client) IsSubscribed(_ context.Context, vni VNI) bool {
+func (c *MBRouteUtil) IsSubscribed(_ context.Context, vni VNI) bool {
 	return c.metalbond.IsSubscribed(vni)
 }
 
-func (c *client) GetRoutesForVni(_ context.Context, vni VNI) error {
+func (c *MBRouteUtil) GetRoutesForVni(_ context.Context, vni VNI) error {
 	return c.metalbond.GetRoutesForVni(vni)
 }


### PR DESCRIPTION
The refactor is mainly inspired by their functions: internal state caching, callback functions by metalbond server, and metalbond client's wrapper (for routing as it is designed for).