### PR TITLE
fix bug where metalbond peer is not initialized

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,13 @@ func main() {
 	mbInstance := mb.NewMetalBond(config, metalnetMBClient)
 	metalbondRouteUtil := metalbond.NewMBRouteUtil(mbInstance)
 
+	for _, metalbondPeer := range metalbondPeers {
+		if err := mbInstance.AddPeer(metalbondPeer, ""); err != nil {
+			setupLog.Error(err, "failed to add metalbond peer", "MetalbondPeer", metalbondPeer)
+			os.Exit(1)
+		}
+	}
+
 	dpdkUUID, err := dpdkProtoClient.CheckInitialized(context.Background(), &dpdkproto.CheckInitializedRequest{})
 	if err != nil {
 		_, err = dpdkProtoClient.Initialize(context.Background(), &dpdkproto.InitializeRequest{})


### PR DESCRIPTION
this is an emergent fix an important bug introduced during refactoring. this bug was not detected by automation tests, which shall be addressed.  