### PR TITLE
Loadbalancer controller should also watch the changes of network objects

### DIFF
--- a/config/samples/networking_v1alpha1_loadbalancer_fra4_lenovo_1.yaml
+++ b/config/samples/networking_v1alpha1_loadbalancer_fra4_lenovo_1.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.metalnet.onmetal.de/v1alpha1
+kind: LoadBalancer
+metadata:
+  name: loadbalancer-sample-fra4-lenovo-1
+spec:
+  ipFamily: IPv4
+  ip: 194.11.242.122
+  type: Public
+  ports:
+  - protocol: TCP
+    port : 80
+  - protocol: UDP
+    port : 80
+  nodeName: fra4-lab-lenovo-1
+  networkRef:
+    name: network-sample

--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func main() {
 		MetalnetCache: metalnetCache,
 		NodeName:      nodeName,
 		PublicVNI:     publicVNI,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, mgr.GetCache()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LoadBalancer")
 		os.Exit(1)
 	}


### PR DESCRIPTION
fix #117 

the issue was that events of Network objects were not able to trigger the reconciliation of LB objects.