### PR TITLE
Fix ` NetworkPeeringStatus` update in network controller

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Pull Request Code test
 
 on:
+  push:
+    branches:
+      - fix-network-controller
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Pull Request Code test
 
 on:
-  push:
-    branches:
-      - fix-network-controller
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
     paths-ignore:

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Network Controller", Label("network"), Ordered, func() {
 					State: metalnetv1alpha1.NetworkPeeringStateReady,
 				}))))
 
-			By("reconciling networks again")
+			By("reconciling networks again to see if status is not overwritten")
 			Expect(networkReconcile(ctx, *network)).To(Succeed())
 			Expect(networkReconcile(ctx, *network2)).To(Succeed())
 

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -217,6 +217,23 @@ var _ = Describe("Network Controller", Label("network"), Ordered, func() {
 					State: metalnetv1alpha1.NetworkPeeringStateReady,
 				}))))
 
+			By("reconciling networks again")
+			Expect(networkReconcile(ctx, *network)).To(Succeed())
+			Expect(networkReconcile(ctx, *network2)).To(Succeed())
+
+			By("validating peering status again")
+			Eventually(Object(network)).Should(SatisfyAll(
+				HaveField("Status.Peerings", ConsistOf(metalnetv1alpha1.NetworkPeeringStatus{
+					ID:    network2.Spec.ID,
+					State: metalnetv1alpha1.NetworkPeeringStateReady,
+				}))))
+
+			Eventually(Object(network2)).Should(SatisfyAll(
+				HaveField("Status.Peerings", ConsistOf(metalnetv1alpha1.NetworkPeeringStatus{
+					ID:    network.Spec.ID,
+					State: metalnetv1alpha1.NetworkPeeringStateReady,
+				}))))
+
 			By("Removing peeredIDs")
 			// Update the k8s network object
 			baseNetwork := network.DeepCopy()

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -309,8 +309,8 @@ func (r *NetworkReconciler) reconcilePeeredVNIs(ctx context.Context, log logr.Lo
 					errs = append(errs, err)
 					continue
 				}
+				delete(networkPeeringState, peeredVNI)
 			}
-			delete(networkPeeringState, peeredVNI)
 		}
 
 		if err := errors.Join(errs...); err != nil {

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -475,16 +475,13 @@ func (r *NetworkReconciler) unsubscribeIfSubscribed(ctx context.Context, vni uin
 func (r *NetworkReconciler) SetupWithManager(mgr ctrl.Manager, metalnetCache cache.Cache) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metalnetv1alpha1.Network{}).
-		// WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Watches(
 			&metalnetv1alpha1.NetworkInterface{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForNetworkInterface),
-			// builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Watches(
 			&metalnetv1alpha1.LoadBalancer{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForLoadBalancer),
-			// builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Complete(r)
 }

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -21,12 +21,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -477,16 +475,16 @@ func (r *NetworkReconciler) unsubscribeIfSubscribed(ctx context.Context, vni uin
 func (r *NetworkReconciler) SetupWithManager(mgr ctrl.Manager, metalnetCache cache.Cache) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metalnetv1alpha1.Network{}).
-		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
+		// WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Watches(
 			&metalnetv1alpha1.NetworkInterface{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForNetworkInterface),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			// builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Watches(
 			&metalnetv1alpha1.LoadBalancer{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForLoadBalancer),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			// builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Complete(r)
 }


### PR DESCRIPTION
# Proposed Changes

- Modify `NetworkController` to delete `peeredVni` only when networks `ownVni` is not available. Previously it was deleting all `peeredVnis` irrespective of if networks `ownVni` is available or not.
- Modify testcase to validate if `NetworkPeeringStatus` remains same after second reconcile also.
- Remove `ResourceVersionChangedPredicate` predicate, as its unnecessarily increasing reconcile loops.

Fixes #256 