### PR TITLE
Improve TAP device handling for ironcore-in-a-box

### DIFF
--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -895,7 +895,10 @@ func (r *NetworkInterfaceReconciler) reconcile(ctx context.Context, log logr.Log
 			log.V(1).Info("Bluefield detected. Converting PCI Bus to the host PCI bus", "PCIAddress", pciAddr)
 		}
 		if r.TapDeviceMode {
-			nic.Status.TAPDevice.Name = pciAddr.Device
+			pciAddr.Device = strings.ReplaceAll(strings.ReplaceAll(pciAddr.Device, ":", ""), ".", "")
+			nic.Status.TAPDevice = &metalnetv1alpha1.TAPDevice{
+				Name: pciAddr.Device,
+			}
 		} else {
 			nic.Status.PCIAddress = &metalnetv1alpha1.PCIAddress{
 				Bus:      pciAddr.Bus,
@@ -1314,9 +1317,26 @@ func (r *NetworkInterfaceReconciler) applyInterface(ctx context.Context, log log
 	return addr, *iface.Spec.UnderlayRoute, false, nil
 }
 
+func (r *NetworkInterfaceReconciler) processTAPDeviceString(device string) (string, error) {
+	cleanedDevice := strings.ReplaceAll(strings.ReplaceAll(device, ":", ""), ".", "")
+
+	const prefix = "dtapvf_"
+	if strings.HasPrefix(cleanedDevice, prefix) {
+		numStr := cleanedDevice[len(prefix):]
+		number, err := strconv.Atoi(numStr)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse device number in %q: %w", cleanedDevice, err)
+		}
+
+		return fmt.Sprintf("net_tap%d", number+2), nil
+	}
+
+	return cleanedDevice, nil
+}
+
 func (r *NetworkInterfaceReconciler) convertToDPDKDevice(addr ghw.PCIAddress) (string, error) {
-	if strings.Contains(addr.Device, "tap") {
-		return strings.ReplaceAll(strings.ReplaceAll(addr.Device, ":", ""), ".", ""), nil
+	if strings.Contains(addr.Device, "dtap") {
+		return r.processTAPDeviceString(addr.Device)
 	}
 	pciFunction, err := strconv.ParseUint(addr.Function, 8, 64)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 	claimStore, err := netfns.NewFileClaimStore(filepath.Join(metalnetDir, "netfns", "claims"), true)
 	Expect(err).NotTo(HaveOccurred())
 
-	initAvailable, err := netfns.CollectTAPFunctions([]string{"net_tap4", "net_tap5"})
+	initAvailable, err := netfns.CollectTAPFunctions([]string{"dtapvf_2", "dtapvf_3"})
 	Expect(err).NotTo(HaveOccurred())
 
 	netFnsManager, err = netfns.NewManager(claimStore, initAvailable)

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func main() {
 			}
 		}
 	} else {
-		initAvailable, err = netfns.CollectTAPFunctions([]string{"net_tap3", "net_tap4", "net_tap5"})
+		initAvailable, err = netfns.CollectTAPFunctions([]string{"dtapvf_0", "dtapvf_1", "dtapvf_2", "dtapvf_3"})
 		if err != nil {
 			setupLog.Error(err, "unable to collect TAP functions")
 			os.Exit(1)

--- a/netfns/netfns.go
+++ b/netfns/netfns.go
@@ -65,7 +65,13 @@ func (s *fileClaimStore) Create(uid types.UID, addr ghw.PCIAddress) error {
 		return ErrClaimAlreadyExists
 	}
 
-	data := []byte(addr.String())
+	var data []byte
+	if !s.isTAPStore {
+		data = []byte(addr.String())
+	} else {
+		data = []byte(addr.Device)
+	}
+
 	return os.WriteFile(filename, data, filePerm)
 }
 


### PR DESCRIPTION
Improve TAP device handling for ironcore-in-a-box.

Linux VF TAP devices are using the pattern dtapvf_X and the DPDK names use the pattern net_tapX.
So adjust the TAP device conversions accordingly similar to the way it is done for the PCI devices.

metalnet API consumers receive the linux names and dpdk grpc library calls use the DPDK name.