### PR TITLE
Add `filterByNodePredicate` to prevent reconciliation of unassigned resources

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/controllers/loadbalancer_controller.go
+++ b/controllers/loadbalancer_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -64,7 +65,7 @@ func (r *LoadBalancerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if nodeName := lb.Spec.NodeName; nodeName == nil || *nodeName != r.NodeName {
+	if !isLoadBalancerAssignedToNode(lb, r.NodeName) {
 		log.V(1).Info("LoadBalancer is not assigned to this node", "NodeName", lb.Spec.NodeName)
 		return ctrl.Result{}, nil
 	}
@@ -344,7 +345,7 @@ func (r *LoadBalancerReconciler) SetupWithManager(mgr ctrl.Manager, metalnetCach
 	ctx := ctrl.LoggerInto(context.TODO(), log)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&metalnetv1alpha1.LoadBalancer{}).
+		For(&metalnetv1alpha1.LoadBalancer{}, builder.WithPredicates(filterByNodePredicate(r.NodeName))).
 		Watches(
 			&metalnetv1alpha1.Network{},
 			r.enqueueLoadBalancersReferencingNetwork(ctx, log),
@@ -364,9 +365,11 @@ func (r *LoadBalancerReconciler) enqueueLoadBalancersReferencingNetwork(ctx cont
 			return nil
 		}
 
-		reqs := make([]ctrl.Request, len(lbList.Items))
-		for i, lb := range lbList.Items {
-			reqs[i] = ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&lb)}
+		reqs := make([]ctrl.Request, 0, len(lbList.Items))
+		for _, lb := range lbList.Items {
+			if isLoadBalancerAssignedToNode(&lb, r.NodeName) {
+				reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&lb)})
+			}
 		}
 		return reqs
 	})

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -493,6 +493,10 @@ func (r *NetworkReconciler) findObjectsForNetworkInterface(ctx context.Context, 
 		return []reconcile.Request{}
 	}
 
+	if !isNetworkInterfaceAssignedToNode(networkInterface, r.NodeName) {
+		return []reconcile.Request{}
+	}
+
 	return []reconcile.Request{{
 		NamespacedName: types.NamespacedName{
 			Name:      networkInterface.Spec.NetworkRef.Name,
@@ -508,6 +512,10 @@ func (r *NetworkReconciler) networkFinalizer() string {
 func (r *NetworkReconciler) findObjectsForLoadBalancer(ctx context.Context, obj client.Object) []reconcile.Request {
 	loadBalancer, ok := obj.(*metalnetv1alpha1.LoadBalancer)
 	if !ok {
+		return []reconcile.Request{}
+	}
+
+	if !isLoadBalancerAssignedToNode(loadBalancer, r.NodeName) {
 		return []reconcile.Request{}
 	}
 

--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -114,7 +115,7 @@ func (r *NetworkInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if nodeName := nic.Spec.NodeName; nodeName == nil || *nodeName != r.NodeName {
+	if !isNetworkInterfaceAssignedToNode(nic, r.NodeName) {
 		log.V(1).Info("Network interface is not assigned to this node", "NodeName", nic.Spec.NodeName)
 		return ctrl.Result{}, nil
 	}
@@ -588,7 +589,7 @@ func (r *NetworkInterfaceReconciler) deleteExistingNATIP(ctx context.Context, lo
 	if err := r.removeNATIPRouteIfExists(ctx, natLocal, underlayRoute, vni); err != nil {
 		return err
 	}
-	log.V(1).Info("Removed nat ip route fi existed")
+	log.V(1).Info("Removed nat ip route if existed")
 
 	log.V(1).Info("Deleting dpdk nat ip if exists")
 	if err := r.deleteDPDKNATIPIfExists(ctx, nic); err != nil {
@@ -1644,7 +1645,7 @@ func (r *NetworkInterfaceReconciler) SetupWithManager(mgr ctrl.Manager, metalnet
 	ctx := ctrl.LoggerInto(context.TODO(), log)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&metalnetv1alpha1.NetworkInterface{}).
+		For(&metalnetv1alpha1.NetworkInterface{}, builder.WithPredicates(filterByNodePredicate(r.NodeName))).
 		Watches(
 			&metalnetv1alpha1.Network{},
 			r.enqueueNetworkInterfacesReferencingNetwork(ctx, log),
@@ -1668,9 +1669,11 @@ func (r *NetworkInterfaceReconciler) enqueueNetworkInterfacesReferencingNetwork(
 			return nil
 		}
 
-		reqs := make([]ctrl.Request, len(nicList.Items))
-		for i, nic := range nicList.Items {
-			reqs[i] = ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&nic)}
+		reqs := make([]ctrl.Request, 0, len(nicList.Items))
+		for _, nic := range nicList.Items {
+			if isNetworkInterfaceAssignedToNode(&nic, r.NodeName) {
+				reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&nic)})
+			}
 		}
 		return reqs
 	})
@@ -1688,9 +1691,11 @@ func (r *NetworkInterfaceReconciler) enqueueNetworkInterfacesReferencingLoadBala
 			return nil
 		}
 
-		reqs := make([]ctrl.Request, len(nicList.Items))
-		for i, nic := range nicList.Items {
-			reqs[i] = ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&nic)}
+		reqs := make([]ctrl.Request, 0, len(nicList.Items))
+		for _, nic := range nicList.Items {
+			if isNetworkInterfaceAssignedToNode(&nic, r.NodeName) {
+				reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&nic)})
+			}
 		}
 		return reqs
 	})

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	metalnetv1alpha1 "github.com/ironcore-dev/metalnet/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func filterByNodePredicate(nodeName string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isResourceAssignedToNode(e.Object, nodeName)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isResourceAssignedToNode(e.ObjectNew, nodeName)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isResourceAssignedToNode(e.Object, nodeName)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isResourceAssignedToNode(e.Object, nodeName)
+		},
+	}
+}
+
+func isResourceAssignedToNode(obj client.Object, nodeName string) bool {
+	if obj == nil {
+		return false
+	}
+
+	switch resource := obj.(type) {
+	case *metalnetv1alpha1.NetworkInterface:
+		return isNetworkInterfaceAssignedToNode(resource, nodeName)
+	case *metalnetv1alpha1.LoadBalancer:
+		return isLoadBalancerAssignedToNode(resource, nodeName)
+	default:
+		return false
+	}
+}
+
+func isNetworkInterfaceAssignedToNode(nic *metalnetv1alpha1.NetworkInterface, nodeName string) bool {
+	return nic.Spec.NodeName != nil && *nic.Spec.NodeName == nodeName
+}
+
+func isLoadBalancerAssignedToNode(lb *metalnetv1alpha1.LoadBalancer, nodeName string) bool {
+	return lb.Spec.NodeName != nil && *lb.Spec.NodeName == nodeName
+}


### PR DESCRIPTION
## Proposed Changes

Implement early filtering using `filterByNodePredicate` to skip reconciliation of unassigned resources.

Fixes #344 