### PR TITLE
Remove possible leftover dpservice containers during CI/CD test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     name: run
     runs-on: [ self-hosted, dpdk ]
     steps:
+      - name: Pre-run cleanup
+        if: always()
+        run: |
+          for i in $(docker ps -q); do docker stop $i; done
+          for i in $(docker ps -aq); do docker rm $i; done
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Fix `Bind for 0.0.0.0:1337 failed: port is already allocated` error, which is observed but rarely.