### PR TITLE
tests: Allow running on IPv6-only hosts

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -76,9 +76,14 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
+	apiServer := &envtest.APIServer{}
+	apiServer.Configure().Set("advertise-address", "127.0.0.1")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+		ControlPlane: envtest.ControlPlane{
+			APIServer: apiServer,
+		},
 	}
 
 	var err error


### PR DESCRIPTION
By explicitly setting `advertise-address` of kube-apiserver, the tests can now run on systems without IPv4 stack. Without the explicit setting, the kube-apiserver would not start on IPv6-only hosts, causing tests to fail.

# Proposed Changes

- Explicitly set `127.0.0.1` as `advertise-address` of kube-apiserver during testing.