### PR TITLE
Mitigate false alarm when lb target routes arrive at a non-lb node

### DIFF
--- a/controllers/loadbalancer_controller.go
+++ b/controllers/loadbalancer_controller.go
@@ -336,6 +336,13 @@ func (r *LoadBalancerReconciler) applyLoadBalancer(ctx context.Context, log logr
 		return netip.Addr{}, err
 	}
 	log.V(1).Info("Added loadbalancer route if not existed")
+
+	// Since it can not be ensured that we have not missed loadbalancer targets we ask for vni routes
+	log.V(1).Info("Get routes and add possibly missing route at the first place", "vni", vni)
+	if err := r.RouteUtil.GetRoutesForVni(ctx, metalbond.VNI(vni)); err != nil {
+		return netip.Addr{}, err
+	}
+
 	return *lbalancer.Spec.UnderlayRoute, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -322,15 +322,6 @@ func main() {
 	mbInstance := mb.NewMetalBond(config, metalnetMBClient)
 	metalbondRouteUtil := metalbond.NewMBRouteUtil(mbInstance)
 
-	for _, metalbondPeer := range metalbondPeers {
-		if err := mbInstance.AddPeer(metalbondPeer, ""); err != nil {
-			setupLog.Error(err, "failed to add metalbond peer", "MetalbondPeer", metalbondPeer)
-			os.Exit(1)
-		}
-	}
-
-	metalnetMBClient.SetMetalBond(mbInstance)
-
 	dpdkUUID, err := dpdkProtoClient.CheckInitialized(context.Background(), &dpdkproto.CheckInitializedRequest{})
 	if err != nil {
 		_, err = dpdkProtoClient.Initialize(context.Background(), &dpdkproto.InitializeRequest{})
@@ -362,6 +353,15 @@ func main() {
 		"metalnetName", protoVersion.ClientName,
 		"metalnetProtocol", protoVersion.ClientProtocol,
 		"metalnetVersion", protoVersion.ClientVersion)
+
+	for _, metalbondPeer := range metalbondPeers {
+		if err := mbInstance.AddPeer(metalbondPeer, ""); err != nil {
+			setupLog.Error(err, "failed to add metalbond peer", "MetalbondPeer", metalbondPeer)
+			os.Exit(1)
+		}
+	}
+
+	metalnetMBClient.SetMetalBond(mbInstance)
 
 	if err := metalnetclient.SetupNetworkInterfaceNetworkRefNameFieldIndexer(context.TODO(), mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to set up field indexer", "Field", metalnetclient.NetworkInterfaceNetworkRefNameField)

--- a/metalbond/metalbond_client.go
+++ b/metalbond/metalbond_client.go
@@ -55,7 +55,8 @@ func (c *MetalnetClient) addLocalRoute(destVni mb.VNI, vni mb.VNI, dest mb.Desti
 		ip := dest.Prefix.Addr().String()
 		uid, ok := c.metalnetCache.GetLoadBalancerServer(uint32(vni), ip)
 		if !ok {
-			return fmt.Errorf("no registered LoadBalancer on this client for vni %d and ip %s", vni, ip)
+			c.log.Info(fmt.Sprintf("no registered LoadBalancer on this client for vni %d and ip %s", vni, ip))
+			return nil
 		}
 
 		if c.config.PreferredNetwork != nil {
@@ -124,7 +125,8 @@ func (c *MetalnetClient) removeLocalRoute(destVni mb.VNI, vni mb.VNI, dest mb.De
 		ip := dest.Prefix.Addr().String()
 		uid, ok := c.metalnetCache.GetLoadBalancerServer(uint32(vni), ip)
 		if !ok {
-			return fmt.Errorf("no registered LoadBalancer on this client for vni %d and ip %s", vni, ip)
+			c.log.Info(fmt.Sprintf("no registered LoadBalancer on this client for vni %d and ip %s", vni, ip))
+			return nil
 		}
 		if _, err := c.dpdk.DeleteLoadBalancerTarget(
 			ctx,


### PR DESCRIPTION
Mitigate false alarm when LB target routes arrive at a non-LB node. 


```
time="2026-06-12T00:52:43Z" level=error msg="Client.RemoveRoute call failed: no registered LoadBalancer on this client for vni 2183930 and ip 194.11.242.30"
time="2026-06-12T00:52:43Z" level=error msg="Client.AddRoute call failed: no registered LoadBalancer on this client for vni 2183930 and ip 194.11.242.30"
```


Re-add received LB target routes once LB is created, to ensure no LB target route is missing in dpservice.