### PR TITLE
controllers: Add `APIReader`s to reconcilers

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -1922,6 +1922,7 @@ func networkReconcile(ctx context.Context, network metalnetv1alpha1.Network) err
 
 	reconciler := &NetworkReconciler{
 		Client:            k8sClient,
+		APIReader:         k8sClient,
 		DPDK:              dpdkClient,
 		RouteUtil:         metalbondRouteUtil,
 		MetalnetCache:     metalnetCache,
@@ -1958,6 +1959,7 @@ func ifaceReconcile(ctx context.Context, networkInterface metalnetv1alpha1.Netwo
 	// Create and initialize Network Interface reconciler
 	reconciler := &NetworkInterfaceReconciler{
 		Client:            k8sClient,
+		APIReader:         k8sClient,
 		EventRecorder:     events.NewFakeRecorder(10),
 		DPDK:              dpdkClient,
 		RouteUtil:         metalbondRouteUtil,
@@ -1993,6 +1995,7 @@ func lbReconcile(ctx context.Context, loadBalancer metalnetv1alpha1.LoadBalancer
 
 	reconciler := &LoadBalancerReconciler{
 		Client:            k8sClient,
+		APIReader:         k8sClient,
 		EventRecorder:     events.NewFakeRecorder(10),
 		DPDK:              dpdkClient,
 		RouteUtil:         metalbondRouteUtil,

--- a/controllers/loadbalancer_controller.go
+++ b/controllers/loadbalancer_controller.go
@@ -40,7 +40,8 @@ const (
 type LoadBalancerReconciler struct {
 	client.Client
 	events.EventRecorder
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 
 	DPDK          dpdkclient.Client
 	MetalnetCache *internal.MetalnetCache
@@ -61,7 +62,7 @@ func (r *LoadBalancerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	lb := &metalnetv1alpha1.LoadBalancer{}
 
-	if err := r.Get(ctx, req.NamespacedName, lb); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, lb); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/controllers/network_controller.go
+++ b/controllers/network_controller.go
@@ -36,7 +36,8 @@ const (
 // NetworkReconciler reconciles metalnetv1alpha1.Network.
 type NetworkReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 
 	DPDK dpdkclient.Client
 
@@ -59,7 +60,7 @@ type NetworkReconciler struct {
 func (r *NetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	network := &metalnetv1alpha1.Network{}
-	if err := r.Get(ctx, req.NamespacedName, network); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, network); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -79,7 +79,8 @@ type NetworkInterfaceReconciler struct {
 	client.Client
 	events.EventRecorder
 
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 
 	DPDK      dpdkclient.Client
 	RouteUtil metalbond.RouteUtil
@@ -111,7 +112,7 @@ func (r *NetworkInterfaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	nic := &metalnetv1alpha1.NetworkInterface{}
 
-	if err := r.Get(ctx, req.NamespacedName, nic); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, nic); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -405,6 +405,7 @@ func main() {
 
 	if err = (&controllers.NetworkReconciler{
 		Client:            mgr.GetClient(),
+		APIReader:         mgr.GetAPIReader(),
 		Scheme:            mgr.GetScheme(),
 		DPDK:              dpdkClient,
 		RouteUtil:         metalbondRouteUtil,
@@ -419,6 +420,7 @@ func main() {
 	}
 	if err = (&controllers.NetworkInterfaceReconciler{
 		Client:                      mgr.GetClient(),
+		APIReader:                   mgr.GetAPIReader(),
 		EventRecorder:               mgr.GetEventRecorder("networkinterface"),
 		Scheme:                      mgr.GetScheme(),
 		DPDK:                        dpdkclient.NewClient(dpdkProtoClient),
@@ -440,6 +442,7 @@ func main() {
 
 	if err = (&controllers.LoadBalancerReconciler{
 		Client:            mgr.GetClient(),
+		APIReader:         mgr.GetAPIReader(),
 		Scheme:            mgr.GetScheme(),
 		EventRecorder:     mgr.GetEventRecorder("loadbalancer"),
 		DPDK:              dpdkclient.NewClient(dpdkProtoClient),


### PR DESCRIPTION
APIReader allows reconcilers to bypass cache and avoid working with potentially stale data. It was added to:

* NetworkReconciler
* NetworkInterfaceReconciler
* LoadBalancerReconciler

This change is a partiall cherry-pick from downstream metalnet[0].

[0] https://github.com/opensovereigncloud/metalnet/commit/c95555b0ebe95c9151ef73dbbde9aafd81f96f30