### PR TITLE
controllers: Simulataneous add/delete of prefixes

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -706,6 +706,48 @@ var _ = Describe("Network Interface and LoadBalancer Controller", func() {
 				Expect(updatedIface.Spec.Prefixes).To(BeEmpty())
 				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
 			})
+			It("Prefixes should handle simultaneous additions and deletions", func() {
+				By("setting up initial prefixes")
+				patchIface := networkInterface.DeepCopy()
+				patchIface.Spec.Prefixes = []metalnetv1alpha1.IPPrefix{
+					metalnetv1alpha1.MustParseIPPrefix("10.0.0.0/24"),
+					metalnetv1alpha1.MustParseIPPrefix("10.1.0.0/24"),
+				}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(networkInterface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *networkInterface)).To(Succeed())
+
+				updatedIface := &metalnetv1alpha1.NetworkInterface{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
+
+				By("removing one prefix and adding a new one simultaneously")
+				patchIface = updatedIface.DeepCopy()
+				patchIface.Spec.Prefixes = []metalnetv1alpha1.IPPrefix{
+					metalnetv1alpha1.MustParseIPPrefix("10.1.0.0/24"), // keep
+					metalnetv1alpha1.MustParseIPPrefix("10.2.0.0/24"), // add
+					// 10.0.0.0/24 implicitly removed
+				}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(updatedIface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *updatedIface)).To(Succeed())
+
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+
+				// Verify DPDK state matches spec exactly — 10.0.0.0/24 gone, 10.2.0.0/24 present
+				prefixList, err := dpdkClient.ListPrefixes(ctx, string(updatedIface.UID))
+				Expect(err).NotTo(HaveOccurred())
+				var activePrefixes []string
+				for _, p := range prefixList.Items {
+					activePrefixes = append(activePrefixes, p.Spec.Prefix.String())
+				}
+				Expect(activePrefixes).To(ConsistOf("10.1.0.0/24", "10.2.0.0/24"))
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
+			})
 
 			It("LoadBalancerTargets should add/update/delete successfully", func() {
 				By("adding the LoadBalancerTarget")
@@ -763,6 +805,45 @@ var _ = Describe("Network Interface and LoadBalancer Controller", func() {
 				}, updatedIface)).To(Succeed())
 
 				Expect(updatedIface.Spec.LoadBalancerTargets).To(BeEmpty())
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
+			})
+
+			It("LoadBalancerTargets should handle simultaneous additions and deletions", func() {
+				By("setting up initial LB targets")
+				patchIface := networkInterface.DeepCopy()
+				patchIface.Spec.LoadBalancerTargets = []metalnetv1alpha1.IPPrefix{
+					metalnetv1alpha1.MustParseIPPrefix("10.0.0.1/32"),
+				}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(networkInterface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *networkInterface)).To(Succeed())
+
+				updatedIface := &metalnetv1alpha1.NetworkInterface{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
+
+				By("removing one LB target and adding a new one simultaneously")
+				patchIface = updatedIface.DeepCopy()
+				patchIface.Spec.LoadBalancerTargets = []metalnetv1alpha1.IPPrefix{
+					metalnetv1alpha1.MustParseIPPrefix("10.1.0.1/32"), // 10.1.0.0 replaces 10.0.0.1
+				}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(updatedIface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *updatedIface)).To(Succeed())
+
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+
+				lbPrefixList, err := dpdkClient.ListLoadBalancerPrefixes(ctx, string(updatedIface.UID))
+				Expect(err).NotTo(HaveOccurred())
+				var activePrefixes []string
+				for _, p := range lbPrefixList.Items {
+					activePrefixes = append(activePrefixes, p.Spec.Prefix.String())
+				}
+				Expect(activePrefixes).To(ConsistOf("10.1.0.1/32"))
 				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
 			})
 
@@ -856,6 +937,103 @@ var _ = Describe("Network Interface and LoadBalancer Controller", func() {
 				fw1, err = dpdkClient.GetFirewallRule(ctx, string(updatedIface.UID), string(fr1.FirewallRuleID))
 				Expect(err).To(HaveOccurred())
 				Expect(fw1.Status.Code).To(Equal(uint32(dpdkerrors.NOT_FOUND)))
+			})
+
+			It("FirewallRules should handle simultaneous additions and deletions", func() {
+				By("setting up initial firewall rules")
+				var protocolType metalnetv1alpha1.ProtocolType = "TCP"
+				var srcPort int32 = 80
+				var dstPort int32 = -1
+				fr1 := metalnetv1alpha1.FirewallRule{
+					FirewallRuleID:    "fr1",
+					Direction:         metalnetv1alpha1.FirewallRuleDirectionIngress,
+					Action:            metalnetv1alpha1.FirewallRuleActionAccept,
+					IpFamily:          "IPv4",
+					SourcePrefix:      metalnetv1alpha1.MustParseNewIPPrefix("0.0.0.0/0"),
+					DestinationPrefix: metalnetv1alpha1.MustParseNewIPPrefix("10.0.0.1/32"),
+					ProtocolMatch: &metalnetv1alpha1.ProtocolMatch{
+						ProtocolType: &protocolType,
+						PortRange: &metalnetv1alpha1.PortMatch{
+							SrcPort:    &srcPort,
+							EndSrcPort: 80,
+							DstPort:    &dstPort,
+						},
+					},
+				}
+				fr2 := metalnetv1alpha1.FirewallRule{
+					FirewallRuleID:    "fr2",
+					Direction:         metalnetv1alpha1.FirewallRuleDirectionIngress,
+					Action:            metalnetv1alpha1.FirewallRuleActionAccept,
+					IpFamily:          "IPv4",
+					SourcePrefix:      metalnetv1alpha1.MustParseNewIPPrefix("0.0.0.0/0"),
+					DestinationPrefix: metalnetv1alpha1.MustParseNewIPPrefix("10.0.0.2/32"),
+					ProtocolMatch: &metalnetv1alpha1.ProtocolMatch{
+						ProtocolType: &protocolType,
+						PortRange: &metalnetv1alpha1.PortMatch{
+							SrcPort:    &srcPort,
+							EndSrcPort: 80,
+							DstPort:    &dstPort,
+						},
+					},
+				}
+				fr3 := metalnetv1alpha1.FirewallRule{
+					FirewallRuleID:    "fr3",
+					Direction:         metalnetv1alpha1.FirewallRuleDirectionIngress,
+					Action:            metalnetv1alpha1.FirewallRuleActionAccept,
+					IpFamily:          "IPv4",
+					SourcePrefix:      metalnetv1alpha1.MustParseNewIPPrefix("0.0.0.0/0"),
+					DestinationPrefix: metalnetv1alpha1.MustParseNewIPPrefix("10.0.0.3/32"),
+					ProtocolMatch: &metalnetv1alpha1.ProtocolMatch{
+						ProtocolType: &protocolType,
+						PortRange: &metalnetv1alpha1.PortMatch{
+							SrcPort:    &srcPort,
+							EndSrcPort: 80,
+							DstPort:    &dstPort,
+						},
+					},
+				}
+
+				patchIface := networkInterface.DeepCopy()
+				patchIface.Spec.FirewallRules = []metalnetv1alpha1.FirewallRule{fr1, fr2}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(networkInterface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *networkInterface)).To(Succeed())
+
+				updatedIface := &metalnetv1alpha1.NetworkInterface{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
+
+				By("removing one firewall rule and adding a new one simultaneously")
+				patchIface = updatedIface.DeepCopy()
+				patchIface.Spec.FirewallRules = []metalnetv1alpha1.FirewallRule{
+					fr2, // keep
+					fr3, // add
+					// fr1 implicitly removed
+				}
+				Expect(k8sClient.Patch(ctx, patchIface, client.MergeFrom(updatedIface))).To(Succeed())
+				Expect(ifaceReconcile(ctx, *updatedIface)).To(Succeed())
+
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name:      networkInterface.Name,
+					Namespace: networkInterface.Namespace,
+				}, updatedIface)).To(Succeed())
+
+				// fr1 must be gone, fr2 kept, fr3 added
+				fw1, err := dpdkClient.GetFirewallRule(ctx, string(updatedIface.UID), string(fr1.FirewallRuleID))
+				Expect(err).To(HaveOccurred())
+				Expect(fw1.Status.Code).To(Equal(uint32(dpdkerrors.NOT_FOUND)))
+
+				fw2, err := dpdkClient.GetFirewallRule(ctx, string(updatedIface.UID), string(fr2.FirewallRuleID))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fw2.Spec.DestinationPrefix.String()).To(Equal("10.0.0.2/32"))
+
+				fw3, err := dpdkClient.GetFirewallRule(ctx, string(updatedIface.UID), string(fr3.FirewallRuleID))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fw3.Spec.DestinationPrefix.String()).To(Equal("10.0.0.3/32"))
+
+				Expect(updatedIface.Status.State).To(Equal(metalnetv1alpha1.NetworkInterfaceStateReady))
 			})
 		})
 

--- a/controllers/networkinterface_controller.go
+++ b/controllers/networkinterface_controller.go
@@ -955,18 +955,11 @@ func (r *NetworkInterfaceReconciler) reconcilePrefixes(ctx context.Context, log 
 		specPrefixes.Insert(specPrefix.Prefix)
 	}
 
-	// Sort prefixes to have deterministic error event output
-	allPrefixes := dpdkPrefixes.UnsortedList()
+	// Use union to ensure ALL prefixes from both sets are processed
+	allPrefixes := dpdkPrefixes.Union(specPrefixes).UnsortedList()
 	sort.Slice(allPrefixes, func(i, j int) bool {
 		return allPrefixes[i].String() < allPrefixes[j].String()
 	})
-
-	if dpdkPrefixes.Len() < specPrefixes.Len() {
-		allPrefixes = specPrefixes.UnsortedList()
-		sort.Slice(allPrefixes, func(i, j int) bool {
-			return allPrefixes[i].String() < allPrefixes[j].String()
-		})
-	}
 	var errs []error
 	for _, prefix := range allPrefixes {
 		if err := func() error {
@@ -1059,18 +1052,11 @@ func (r *NetworkInterfaceReconciler) reconcileLBTargets(ctx context.Context, log
 		specPrefixes.Insert(specPrefix.Prefix)
 	}
 
-	// Sort prefixes to have deterministic error event output
-	allPrefixes := dpdkPrefixes.UnsortedList()
+	// Use union to ensure ALL prefixes from both sets are processed
+	allPrefixes := dpdkPrefixes.Union(specPrefixes).UnsortedList()
 	sort.Slice(allPrefixes, func(i, j int) bool {
 		return allPrefixes[i].String() < allPrefixes[j].String()
 	})
-
-	if dpdkPrefixes.Len() < specPrefixes.Len() {
-		allPrefixes = specPrefixes.UnsortedList()
-		sort.Slice(allPrefixes, func(i, j int) bool {
-			return allPrefixes[i].String() < allPrefixes[j].String()
-		})
-	}
 	var errs []error
 	for _, prefix := range allPrefixes {
 		if err := func() error {
@@ -1159,17 +1145,10 @@ func (r *NetworkInterfaceReconciler) reconcileFirewallRules(ctx context.Context,
 	}
 
 	// Sort FirewallRules to have deterministic error event output
-	allFirewallRules := dpdkFirewallRules.UnsortedList()
+	allFirewallRules := dpdkFirewallRules.Union(specFirewallRules).UnsortedList()
 	sort.Slice(allFirewallRules, func(i, j int) bool {
 		return allFirewallRules[i] < allFirewallRules[j]
 	})
-
-	if dpdkFirewallRules.Len() < specFirewallRules.Len() {
-		allFirewallRules = specFirewallRules.UnsortedList()
-		sort.Slice(allFirewallRules, func(i, j int) bool {
-			return allFirewallRules[i] < allFirewallRules[j]
-		})
-	}
 	var errs []error
 	var specFirewallRule metalnetv1alpha1.FirewallRule
 	for _, fwRuleID := range allFirewallRules {


### PR DESCRIPTION
`NetworkInterfaceReconciler` would fail to properly reconcile some objects if their spec was changed without changing the amount of items in the spec (e.g. 1 prefix added, 1 removed). This issue affected reconciliation of:
  * Prefixes
  * LBTargets
  * FirewallRules

The new approach merges all items from DPDK and spec sources, before processing each item and figuring out if the item should stay/be added/be removed.

This change is partially cherry-pick from downstream metalnet[0]. One notable difference is that the downstream fix does not address the issue for FirewallRules reconciliation.

[0] https://github.com/opensovereigncloud/metalnet/commit/c95555b0ebe95c9151ef73dbbde9aafd81f96f30